### PR TITLE
config: Update the NicClusterPolicy name

### DIFF
--- a/configs/base/nic.yaml
+++ b/configs/base/nic.yaml
@@ -2,7 +2,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
-  name: aks-nic-cluster-policy
+  name: nic-cluster-policy
 spec:
   # This is needed so that you don't schedule pods on the non-infiniband machines.
   nodeAffinity:

--- a/configs/ipoib/ipoib.yaml
+++ b/configs/ipoib/ipoib.yaml
@@ -2,7 +2,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
-  name: aks-nic-cluster-policy
+  name: nic-cluster-policy
 spec:
   secondaryNetwork:
     cniPlugins:

--- a/configs/rdma-shared-device-plugin/rdma.yaml
+++ b/configs/rdma-shared-device-plugin/rdma.yaml
@@ -12,6 +12,7 @@ spec:
     useCdi: true
     # The config below directly propagates to k8s-rdma-shared-device-plugin configuration.
     # Replace 'devices' with your (RDMA capable) netdevice name.
+    # 15b3 is the vendor id for Nvidia NIC by Mellanox: https://admin.pci-ids.ucw.cz/read/PC/15b3
     config: |
       {
         "configList": [
@@ -19,7 +20,7 @@ spec:
             "resourceName": "rdma_shared_device_a",
             "rdmaHcaMax": 63,
             "selectors": {
-              "vendors": ["15b3"], # Mellanox
+              "vendors": ["15b3"]
             }
           }
         ]

--- a/configs/rdma-shared-device-plugin/rdma.yaml
+++ b/configs/rdma-shared-device-plugin/rdma.yaml
@@ -2,7 +2,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
-  name: aks-nic-cluster-policy
+  name: nic-cluster-policy
 spec:
   rdmaSharedDevicePlugin:
     repository: ghcr.io/mellanox

--- a/configs/sriov-device-plugin/sriov.yaml
+++ b/configs/sriov-device-plugin/sriov.yaml
@@ -2,7 +2,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
-  name: aks-nic-cluster-policy
+  name: nic-cluster-policy
 spec:
   sriovDevicePlugin:
     repository: ghcr.io/k8snetworkplumbingwg


### PR DESCRIPTION
Turns out that the NicClusterPolicy CR can only be called `nic-cluster-policy`. Otherwise the operator will ignore the CR. This commit updates the name of the NicClusterPolicy CR in the configs from `aks-nic-cluster-policy` to `nic-cluster-policy`.

Here is the status message on the custom-resource that the operator throws when the CR name is not `nic-cluster-policy`:

```yaml
status:
  reason: Unsupported NicClusterPolicy instance aks-nic-cluster-policy. Only
    instance with name nic-cluster-policy is supported
  state: ignore
```

---

rdma-device-plugin: Fix misformatted JSON config

The JSON config had an extra comma and a # comment which is not allowed.