### PR TITLE
chore: only deploy network-operator operands to non-system nodes

### DIFF
--- a/configs/nicclusterpolicy/base/nic.yaml
+++ b/configs/nicclusterpolicy/base/nic.yaml
@@ -4,17 +4,6 @@ kind: NicClusterPolicy
 metadata:
   name: nic-cluster-policy
 spec:
-  # This is needed so that you don't schedule pods on the non-infiniband machines.
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        # This node label is added by NFD.
-        - key: feature.node.kubernetes.io/pci-15b3.present
-          operator: In
-          values:
-          - "true"
-
   ofedDriver:
     repository: nvcr.io/nvidia/mellanox
     image: doca-driver

--- a/configs/values/network-operator/values.yaml
+++ b/configs/values/network-operator/values.yaml
@@ -1,2 +1,12 @@
-nfd:
-  deployNodeFeatureRules: false
+node-feature-discovery:
+  worker:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            # Don't schedule NFD workers on the system nodepool.
+            - key: kubernetes.azure.com/mode
+              operator: NotIn
+              values:
+              - system


### PR DESCRIPTION
Currently, we are deploying network-operator operands like mofed drivers to all nodes. Adding this node selector term will allow us to isolate network-operator deployment to non-system nodes only.