### PR TITLE
Update gpu-operator and vllm versions

### DIFF
--- a/tests/containers/ibtools/Dockerfile
+++ b/tests/containers/ibtools/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -LO https://github.com/Mellanox/sockperf/archive/refs/heads/sockperf_v2
     ./autogen.sh && ./configure && make && make install && \
     cd -
 
-FROM vllm/vllm-openai:v0.8.1
+FROM vllm/vllm-openai:v0.8.2
 
 # Copy the sockperf binary from the build stage
 COPY --from=build-stage /usr/local/bin/sockperf /usr/local/bin/sockperf

--- a/tests/setup-infra/deploy-aks.sh
+++ b/tests/setup-infra/deploy-aks.sh
@@ -17,6 +17,9 @@ fi
 : "${CLUSTER_NAME:=ib-aks-cluster}"
 : "${USER_NAME:=azureuser}"
 
+# Versions
+: "${GPU_OPERATOR_VERSION:=v25.3.0}"
+
 # deploy_aks creates a resource gropu and a new AKS cluster with the provided
 # arguments. You can provide additional arguments to the function. For example a
 # call would look like this: `deploy_aks --enable-addons monitoring`
@@ -124,7 +127,7 @@ function install_gpu_operator() {
         --values ${SCRIPT_DIR}/../../configs/values/gpu-operator/values.yaml \
         gpu-operator \
         nvidia/gpu-operator \
-        --version v24.9.2
+        --version "${GPU_OPERATOR_VERSION}"
 
     cuda_validator_label="app=nvidia-cuda-validator"
 

--- a/website/docs/configurations/02-gpu-operator.md
+++ b/website/docs/configurations/02-gpu-operator.md
@@ -2,10 +2,10 @@
 title: GPU Operator
 ---
 
-This guide details recommended configurations for GPU Operator v24.9.2 to enable GPU workload, with specific settings for GPUDirect RDMA integration.
+This guide details recommended configurations for GPU Operator to enable GPU workload, with specific settings for GPUDirect RDMA integration.
 
 :::tip
-This guide assumes a basic understanding of GPU Operator and its role in Kubernetes clusters. Readers unfamiliar with GPU Operator are advised to review the official [guide](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html) before proceeding. The concepts and recommended configurations presented here build on that foundation to enable GPU workload and GPUDirect RDMA in AKS. This documentation is based on GPU Operator v24.9.2.
+This guide assumes a basic understanding of GPU Operator and its role in Kubernetes clusters. Readers unfamiliar with GPU Operator are advised to review the official [guide](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html) before proceeding. The concepts and recommended configurations presented here build on that foundation to enable GPU workload and GPUDirect RDMA in AKS.
 :::
 
 ## GPU Drivers: AKS-managed vs. GPU Operator-managed
@@ -34,7 +34,7 @@ Please proceed with GPU operator installation only if you have created the nodep
 
 ### Operator
 
-GPU Operator is deployed using [Helm](https://helm.sh/), and the [default Helm values](https://github.com/NVIDIA/gpu-operator/blob/v24.9.2/deployments/gpu-operator/values.yaml) are customized to align with the Network Operator and AKS requirements. Key adjustments to the Helm values disable redundant components such as NFD and enable RDMA support.
+GPU Operator is deployed using [Helm](https://helm.sh/), and the [default Helm values](https://github.com/NVIDIA/gpu-operator/blob/v25.3.0/deployments/gpu-operator/values.yaml) are customized to align with the Network Operator and AKS requirements. Key adjustments to the Helm values disable redundant components such as NFD and enable RDMA support.
 
 GPU operator deploys pods that require privileged access to the host system. To ensure proper operation, the `gpu-operator` namespace must be labeled with `pod-security.kubernetes.io/enforce=privileged`.
 
@@ -59,7 +59,7 @@ helm upgrade --install \
   --create-namespace -n gpu-operator \
   gpu-operator nvidia/gpu-operator \
   -f values.yaml \
-  --version v24.9.2
+  --version v25.3.0
 ```
 
 ## Usage of GPUDirect RDMA


### PR DESCRIPTION
- gpu-operator: Update from v24.9.2 to v25.3.0
    - Also remove the references to the version 24.9.2 in the documentation, so as to reduce our maintenance burden.
- test-ibtools: Update vllm from v0.8.1 to v0.8.2

Fixes #17 #18