### PR TITLE
actions: ibtools-image is failing due to low disk space

### DIFF
--- a/.github/workflows/build-ibtools-image.yaml
+++ b/.github/workflows/build-ibtools-image.yaml
@@ -18,6 +18,14 @@ jobs:
       packages: write
 
     steps:
+    - name: Maximize build space
+      uses: AdityaGarg8/remove-unwanted-software@v5
+      with:
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Set up Docker Buildx


### PR DESCRIPTION
This commit adds a step that increases the disk space available for the pipeline.

Fixes build space issue here: https://github.com/Azure/aks-rdma-infiniband/actions/runs/14202629411