### PR TITLE
nicclusterpolicy: Add env var `OFED_BLACKLIST_MODULES_FILE`

### DIFF
--- a/configs/nicclusterpolicy/base/nic.yaml
+++ b/configs/nicclusterpolicy/base/nic.yaml
@@ -22,6 +22,12 @@ spec:
     # When this is deployed a suffix is added in the format "-<os><os version>-<cpu arch>" for e.g.: "-ubuntu22.04-amd64".
     version: 25.01-0.6.0.0-0
 
+    env:
+    # TODO: Temporary fix to avoid race condition where the kernel module fails to load.
+    # Refer: https://github.com/Mellanox/doca-driver-build/issues/52
+    - name: OFED_BLACKLIST_MODULES_FILE
+      value: "/host/etc/modprobe.d/blacklist-ofed-modules.conf"
+
     forcePrecompiled: false
     upgradePolicy:
       autoUpgrade: true


### PR DESCRIPTION
This commit adds an env var
`OFED_BLACKLIST_MODULES_FILE=/host/etc/modprobe.d/blacklist-ofed-modules.conf`.

This is done to avoid the race condition where the driver container tries to reload the module but cannot because the host loads the modules shipped with the kernel.

This workaround ensures that the blacklist file is present on the host, so that the host does not interfere with the module load process.