### PR TITLE
renovate: Add gpu-operator, network-operator & MPI Operator configs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,5 +18,37 @@
             ],
             "enabled": false
         }
+    ],
+    "regexManagers": [
+        {
+            "registryUrlTemplate": "https://helm.ngc.nvidia.com/nvidia",
+            "depNameTemplate": "gpu-operator",
+            "datasourceTemplate": "helm",
+            "versioningTemplate": "semver",
+            "fileMatch": [
+                "tests/setup-infra/deploy-aks.sh",
+                "website/docs/configurations/02-gpu-drivers.md"
+            ],
+            "matchStrings": [
+                ": \"\\${GPU_OPERATOR_VERSION:=(?<currentValue>.*?)}\"",
+                "https://github.com/NVIDIA/gpu-operator/blob/(?<currentValue>.*?)/deployments/gpu-operator/values.yaml",
+                "(?m)^\\s*--version (?<currentValue>v?[0-9.]+)"
+            ]
+        },
+        {
+            "registryUrlTemplate": "https://helm.ngc.nvidia.com/nvidia",
+            "depNameTemplate": "network-operator",
+            "datasourceTemplate": "helm",
+            "versioningTemplate": "semver",
+            "fileMatch": [
+                "tests/setup-infra/deploy-aks.sh",
+                "website/docs/configurations/01-network-operator.md"
+            ],
+            "matchStrings": [
+                ": \"\\${NETWORK_OPERATOR_VERSION:=v(?<currentValue>.*?)}\"",
+                "https://github.com/Mellanox/network-operator/blob/v(?<currentValue>.*?)/deployment/network-operator/values.yaml",
+                "(?m)^\\s*--version v(?<currentValue>v?[0-9.]+)"
+            ]
+        }
     ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,6 +49,17 @@
                 "https://github.com/Mellanox/network-operator/blob/v(?<currentValue>.*?)/deployment/network-operator/values.yaml",
                 "(?m)^\\s*--version v(?<currentValue>v?[0-9.]+)"
             ]
+        },
+        {
+            "depNameTemplate": "kubeflow/mpi-operator",
+            "datasourceTemplate": "github-releases",
+            "versioningTemplate": "semver",
+            "fileMatch": [
+                "tests/setup-infra/deploy-aks.sh"
+            ],
+            "matchStrings": [
+                ":\\s*\"\\${MPI_OPERATOR_VERSION:=v(?<currentValue>[0-9.]+)}\""
+            ]
         }
     ]
 }

--- a/tests/setup-infra/deploy-aks.sh
+++ b/tests/setup-infra/deploy-aks.sh
@@ -20,6 +20,7 @@ fi
 
 # Versions
 : "${GPU_OPERATOR_VERSION:=v25.3.0}"
+: "${NETWORK_OPERATOR_VERSION:=v25.1.0}"
 : "${MPI_OPERATOR_VERSION:=v0.6.0}" # Latest version: https://github.com/kubeflow/mpi-operator/releases
 
 function check_prereqs() {
@@ -115,7 +116,7 @@ function install_network_operator() {
         --values "${SCRIPT_DIR}"/../../configs/values/network-operator/values.yaml \
         network-operator \
         nvidia/network-operator \
-        --version v25.1.0
+        --version "${NETWORK_OPERATOR_VERSION}"
 
     kubectl apply -f "${SCRIPT_DIR}"/network-operator-nfd.yaml
     kubectl apply -k "${SCRIPT_DIR}"/../../configs/nicclusterpolicy/base

--- a/website/docs/configurations/01-network-operator.md
+++ b/website/docs/configurations/01-network-operator.md
@@ -2,10 +2,10 @@
 title: Network Operator
 ---
 
-This guide details recommended configurations for Network Operator v25.1.0 to enable RDMA over InfiniBand, optimized for AKS environments with Mellanox NICs.
+This guide details recommended configurations for Network Operator to enable RDMA over InfiniBand, optimized for AKS environments with Mellanox NICs.
 
 :::tip
-This guide assumes a basic understanding of Network Operator and its role in Kubernetes clusters. Readers unfamiliar with the Network Operator are advised to review the official [Getting Started Guide](https://docs.nvidia.com/networking/display/kubernetes2501/getting-started-kubernetes.html) before proceeding. The concepts and recommended configurations presented here build on that foundation to enable RDMA over InfiniBand in AKS. This documentation is based on Network Operator v25.1.0.
+This guide assumes a basic understanding of Network Operator and its role in Kubernetes clusters. Readers unfamiliar with the Network Operator are advised to review the official [Getting Started Guide](https://docs.nvidia.com/networking/display/kubernetes2501/getting-started-kubernetes.html) before proceeding. The concepts and recommended configurations presented here build on that foundation to enable RDMA over InfiniBand in AKS.
 :::
 
 ## Network Operator Deployment


### PR DESCRIPTION
This commit adds configuration to update GPU-Operator and Network-Operator. The configuration is identical to each other. The obvious differences are the fields `depNameTemplate` and `fileMatch`.

Renovate refers to the `index.yaml` file here to identify the versions of the operators: https://helm.ngc.nvidia.com/nvidia/index.yaml. GPU-operator and Network-Operator both publish the versions differently, GPU-operator appends `v` before the semver and Network-Operator does not.

Here is the snippet of `gpu-operator`:

```yaml
  gpu-operator:
  - apiVersion: v2
    appVersion: v25.3.0
    ...
    urls:
    - charts/gpu-operator-v25.3.0.tgz
    version: v25.3.0
```

And here is the snippet of `network-operator`:

```yaml
  network-operator:
  appVersion: v25.4.0
  - apiVersion: v2
    ...
    urls:
    - charts/network-operator-25.4.0.tgz
    version: 25.4.0
```

Hence the non-obvious difference is that the `matchStrings` for `network-operator` has `v` prefix added to the semver.