### PR TITLE
chore(deps): update step-security/harden-runner digest to 002fdce

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Harden Runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863
         with:
           disable-sudo: true
           egress-policy: block


### PR DESCRIPTION
Right now renovate is not enabled, so pushed the PR from my fork here. More info here: https://github.com/surajssd/aks-rdma-infiniband/pull/1