### PR TITLE
chore(deps): update actions/cache action to v4.2.3

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -49,7 +49,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" > $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-website-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
Right now renovate is not enabled, so pushed the PR from my fork here. More info here: https://github.com/surajssd/aks-rdma-infiniband/pull/2