### PR TITLE
chore(deps): update helm release network-operator to v25.4.0 and sub-components

### DIFF
--- a/configs/nicclusterpolicy/base/nic.yaml
+++ b/configs/nicclusterpolicy/base/nic.yaml
@@ -20,7 +20,7 @@ spec:
     image: doca-driver
     # Latest tag: https://catalog.ngc.nvidia.com/orgs/nvidia/teams/mellanox/containers/doca-driver/tags
     # When this is deployed a suffix is added in the format "-<os><os version>-<cpu arch>" for e.g.: "-ubuntu22.04-amd64".
-    version: 25.01-0.6.0.0-0
+    version: 25.04-0.6.1.0-2
 
     env:
     # TODO: Temporary fix to avoid race condition where the kernel module fails to load.

--- a/configs/nicclusterpolicy/ipoib/ipoib.yaml
+++ b/configs/nicclusterpolicy/ipoib/ipoib.yaml
@@ -9,7 +9,7 @@ spec:
       repository: ghcr.io/k8snetworkplumbingwg
       image: plugins
       # Latest tag: https://github.com/k8snetworkplumbingwg/plugins/pkgs/container/plugins
-      version: v1.5.0
+      version: v1.6.2-update.1
 
     multus:
       repository: ghcr.io/k8snetworkplumbingwg
@@ -21,7 +21,7 @@ spec:
       repository: ghcr.io/mellanox
       image: ipoib-cni
       # Latest tag: https://github.com/mellanox/ipoib-cni/pkgs/container/ipoib-cni
-      version: v1.2.1
+      version: v1.2.2
 
     ipamPlugin:
       repository: ghcr.io/k8snetworkplumbingwg

--- a/configs/nicclusterpolicy/rdma-shared-device-plugin/rdma.yaml
+++ b/configs/nicclusterpolicy/rdma-shared-device-plugin/rdma.yaml
@@ -8,7 +8,7 @@ spec:
     repository: ghcr.io/mellanox
     image: k8s-rdma-shared-dev-plugin
     # Latest tag: https://github.com/mellanox/k8s-rdma-shared-dev-plugin/pkgs/container/k8s-rdma-shared-dev-plugin
-    version: v1.5.2
+    version: v1.5.3
     # The config below directly propagates to k8s-rdma-shared-device-plugin configuration.
     # Replace 'devices' with your (RDMA capable) netdevice name.
     # 15b3 is the vendor id for Nvidia NIC by Mellanox: https://admin.pci-ids.ucw.cz/read/PC/15b3

--- a/tests/setup-infra/deploy-aks.sh
+++ b/tests/setup-infra/deploy-aks.sh
@@ -20,7 +20,7 @@ fi
 
 # Versions
 : "${GPU_OPERATOR_VERSION:=v25.3.1}"
-: "${NETWORK_OPERATOR_VERSION:=v25.1.0}"
+: "${NETWORK_OPERATOR_VERSION:=v25.4.0}"
 : "${MPI_OPERATOR_VERSION:=v0.6.0}" # Latest version: https://github.com/kubeflow/mpi-operator/releases
 
 function check_prereqs() {

--- a/website/docs/configurations/01-network-operator.md
+++ b/website/docs/configurations/01-network-operator.md
@@ -5,7 +5,7 @@ title: Network Operator
 This guide details recommended configurations for Network Operator to enable RDMA over InfiniBand, optimized for AKS environments with Mellanox NICs.
 
 :::tip
-This guide assumes a basic understanding of Network Operator and its role in Kubernetes clusters. Readers unfamiliar with the Network Operator are advised to review the official [Getting Started Guide](https://docs.nvidia.com/networking/display/kubernetes2501/getting-started-kubernetes.html) before proceeding. The concepts and recommended configurations presented here build on that foundation to enable RDMA over InfiniBand in AKS.
+This guide assumes a basic understanding of Network Operator and its role in Kubernetes clusters. Readers unfamiliar with the Network Operator are advised to review the official [Getting Started Guide](https://docs.nvidia.com/networking/display/kubernetes2540/getting-started-kubernetes.html) before proceeding. The concepts and recommended configurations presented here build on that foundation to enable RDMA over InfiniBand in AKS.
 :::
 
 ## Network Operator Deployment
@@ -211,4 +211,4 @@ The installation process follows this sequence:
 
 RDMA over InfiniBand operates below the TCP/IP stack, relying on direct memory access rather than IP-based networking. Tools like [Multus](https://github.com/k8snetworkplumbingwg/multus-cni) and [whereabouts](https://github.com/k8snetworkplumbingwg/whereabouts) for secondary network attachment and IPAM are not strictly required for RDMA over InfiniBand in AKS, as Device Plugins directly expose InfiniBand resources to pods.
 
-If you wish to operate in the TCP/IP stack over the InfiniBand network, refer to the [NVIDIA Getting Started Guide for Kubernetes](https://docs.nvidia.com/networking/display/kubernetes2501/getting-started-kubernetes.html) for detailed instructions.
+If you wish to operate in the TCP/IP stack over the InfiniBand network, refer to the [NVIDIA Getting Started Guide for Kubernetes](https://docs.nvidia.com/networking/display/kubernetes2540/getting-started-kubernetes.html) for detailed instructions.

--- a/website/docs/configurations/01-network-operator.md
+++ b/website/docs/configurations/01-network-operator.md
@@ -12,7 +12,7 @@ This guide assumes a basic understanding of Network Operator and its role in Kub
 
 ### Operator
 
-Network Operator is deployed using [Helm](https://helm.sh/), and the [default Helm values](https://github.com/Mellanox/network-operator/blob/v25.1.0/deployment/network-operator/values.yaml) are recommended unless specific customizations are required. These defaults include [Node Feature Discovery (NFD)](https://kubernetes-sigs.github.io/node-feature-discovery/stable/get-started/index.html), a critical dependency that labels nodes with hardware details (e.g., Mellanox NIC presence) for pod scheduling.
+Network Operator is deployed using [Helm](https://helm.sh/), and the [default Helm values](https://github.com/Mellanox/network-operator/blob/v25.4.0/deployment/network-operator/values.yaml) are recommended unless specific customizations are required. These defaults include [Node Feature Discovery (NFD)](https://kubernetes-sigs.github.io/node-feature-discovery/stable/get-started/index.html), a critical dependency that labels nodes with hardware details (e.g., Mellanox NIC presence) for pod scheduling.
 
 Network operator deploys pods that require privileged access to the host system. To ensure proper operation, the `network-operator` namespace must be labeled with `pod-security.kubernetes.io/enforce=privileged`.
 
@@ -37,7 +37,7 @@ helm upgrade --install \
   --create-namespace -n network-operator \
   network-operator nvidia/network-operator \
   -f values.yaml \
-  --version v25.1.0
+  --version v25.4.0
 ```
 
 ### Node Feature Rule

--- a/website/docs/getting-started/02-prerequisites.md
+++ b/website/docs/getting-started/02-prerequisites.md
@@ -8,7 +8,7 @@ This section details the prerequisites for deploying an AKS cluster with support
 
 An active AKS cluster is required as the foundation for deploying RDMA over InfiniBand capabilities. The cluster serves as the Kubernetes environment where Network Operator and GPU Operator (if using GPUDirect RDMA) will be installed.
 
-- **Requirement**: Create an AKS cluster using the [Azure Portal](https://portal.azure.com) or [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/aks?view=azure-cli-latest). Ensure the cluster is running a supported Kubernetes version compatible with [Network Operator](https://docs.nvidia.com/networking/display/kubernetes2501/platform-support.html) and / or [GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html).
+- **Requirement**: Create an AKS cluster using the [Azure Portal](https://portal.azure.com) or [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/aks?view=azure-cli-latest). Ensure the cluster is running a supported Kubernetes version compatible with [Network Operator](https://docs.nvidia.com/networking/display/kubernetes2540/platform-support.html) and / or [GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html).
 - **Configuration**: The cluster must be deployed in a region that supports the required VM sizes with RDMA over InfiniBand capabilities.
 
 To create an AKS cluster, use the following Azure CLI command as a starting point:


### PR DESCRIPTION
- Bump `doca-driver` from 25.01-0.6.0.0-0 to 25.04-0.6.1.0-2
- Bump `ipoib-cni` from v1.2.1 to v1.2.2
- Bump `plugins` from v1.5.0 to v1.6.2-update.1
- Bump `k8s-rdma-shared-dev-plugin` from v1.5.2 to v1.5.3
- Update documentation links to reference NVIDIA Kubernetes v25.4.0 docs (was
  25.1.0)

These updates align with the latest stable versions and ensure compatibility
with recent Kubernetes and AKS environments.

Source:
https://docs.nvidia.com/networking/display/kubernetes2540/platform-support.html


