### PR TITLE
Add RCCL test image

### DIFF
--- a/.github/workflows/build-rccl-tests-image.yaml
+++ b/.github/workflows/build-rccl-tests-image.yaml
@@ -1,0 +1,58 @@
+name: Build & Push RCCL Tests Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - tests/containers/rccl-tests/Dockerfile
+      - .github/workflows/build-rccl-tests-image.yaml
+
+  workflow_dispatch:
+
+jobs:
+  build_push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Maximize build space
+      uses: AdityaGarg8/remove-unwanted-software@v5
+      with:
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
+    - name: Checkout code
+      uses: actions/checkout@v6
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Login to GHCR
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor}}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Generate tags
+      id: tag
+      uses: docker/metadata-action@v6
+      with:
+        images: ghcr.io/Azure/aks-rdma-infiniband/rccl-tests
+        tags: |
+          type=raw,value=latest
+          type=schedule,pattern={{date 'YYYYMMDD-hhmmss' tz='America/Los_Angeles'}}
+
+    - name: Build and push
+      uses: docker/build-push-action@v7
+      with:
+        context: tests/containers/rccl-tests/
+        file: tests/containers/rccl-tests/Dockerfile
+        platforms: linux/amd64
+        push: true
+        tags: ${{ steps.tag.outputs.tags }}
+        labels: ${{ steps.tag.outputs.labels }}

--- a/tests/containers/rccl-tests/Dockerfile
+++ b/tests/containers/rccl-tests/Dockerfile
@@ -1,0 +1,23 @@
+FROM rocm/dev-ubuntu-24.04:6.3.4 AS builder
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    git make g++ libopenmpi-dev openmpi-bin libibverbs-dev librdmacm-dev rccl-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/ROCm/rccl-tests.git /rccl-tests && \
+    cd /rccl-tests && \
+    make MPI=1 HIP_HOME=/opt/rocm RCCL_HOME=/opt/rocm MPI_HOME=/usr/lib/x86_64-linux-gnu/openmpi GPU_TARGETS=gfx942
+
+FROM rocm/dev-ubuntu-24.04:6.3.4
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    openssh-server openssh-client openmpi-bin libopenmpi-dev \
+    libibverbs-dev librdmacm-dev numactl rccl && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /var/run/sshd && \
+    sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config && \
+    sed -i 's/#StrictModes.*/StrictModes no/' /etc/ssh/sshd_config && \
+    ssh-keygen -A
+
+COPY --from=builder /rccl-tests/build /opt/rccl-tests/build


### PR DESCRIPTION
Add RCCL tests container image build workflow

  Summary

  - Adds tests/containers/rccl-tests/Dockerfile to build https://github.com/ROCm/rccl-tests on top of https://hub.docker.com/r/rocm/dev-ubuntu-24.04, compiled with MPI=1 for GPU_TARGETS=gfx942 (MI300X).
  - Adds .github/workflows/build-rccl-tests-image.yaml to publish the image to ghcr.io/Azure/aks-rdma-infiniband/rccl-tests:latest — mirrors the existing build-nccl-tests-image.yaml workflow.
  - Built only for linux/amd64 since the https://hub.docker.com/u/rocm are amd64-only.

  Motivation

  Provides an AMD GPU counterpart to the existing nccl-tests image so RCCL collective benchmarks can be run on AKS MI300X node pools using the same MPI-based test scenarios. See upstream
  https://github.com/ROCm/rccl and https://github.com/ROCm/rccl-tests.

  Test plan

  - Workflow triggers on push to main when Dockerfile/workflow changes
  - Manual workflow_dispatch run succeeds
  - Image appears at https://github.com/Azure/aks-rdma-infiniband/pkgs/container/aks-rdma-infiniband%2Frccl-tests
  - docker run --rm ghcr.io/azure/aks-rdma-infiniband/rccl-tests:latest ls /opt/rccl-tests/build lists the compiled benchmarks (all_reduce_perf, all_gather_perf, etc.)
  - Pull the image on an MI300X node pool and run all_reduce_perf via MPI to verify the binaries execute against a real GPU