### PR TITLE
chore(deps): update vllm-openai, gpu-operator, and rocm docker tags

### DIFF
--- a/tests/containers/ibtools/Dockerfile
+++ b/tests/containers/ibtools/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -LO https://github.com/Mellanox/sockperf/archive/refs/heads/sockperf_v2
     ./autogen.sh && ./configure && make && make install && \
     cd -
 
-FROM vllm/vllm-openai:v0.21.0
+FROM vllm/vllm-openai:v0.22.0
 
 # Copy the sockperf binary from the build stage
 COPY --from=build-stage /usr/local/bin/sockperf /usr/local/bin/sockperf

--- a/tests/containers/rccl-tests/Dockerfile
+++ b/tests/containers/rccl-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocm/dev-ubuntu-24.04:7.2.3 AS builder
+FROM rocm/dev-ubuntu-24.04:7.2.4 AS builder
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     git make g++ libopenmpi-dev openmpi-bin libibverbs-dev librdmacm-dev rccl-dev && \
@@ -8,7 +8,7 @@ RUN git clone --depth 1 https://github.com/ROCm/rccl-tests.git /rccl-tests && \
     cd /rccl-tests && \
     make MPI=1 HIP_HOME=/opt/rocm RCCL_HOME=/opt/rocm MPI_HOME=/usr/lib/x86_64-linux-gnu/openmpi GPU_TARGETS=gfx942
 
-FROM rocm/dev-ubuntu-24.04:7.2.3
+FROM rocm/dev-ubuntu-24.04:7.2.4
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     openssh-server openssh-client openmpi-bin libopenmpi-dev \

--- a/tests/setup-infra/deploy-aks.sh
+++ b/tests/setup-infra/deploy-aks.sh
@@ -20,7 +20,7 @@ fi
 : "${CLUSTER_OS:=Ubuntu}"
 
 # Versions
-: "${GPU_OPERATOR_VERSION:=v26.3.1}"
+: "${GPU_OPERATOR_VERSION:=v26.3.2}"
 : "${NETWORK_OPERATOR_VERSION:=v26.1.1}"
 : "${MPI_OPERATOR_VERSION:=v0.8.0}" # Latest version: https://github.com/kubeflow/mpi-operator/releases
 : "${AMD_GPU_OPERATOR_VERSION:=v1.4.1}" # https://github.com/ROCm/gpu-operator/releases

--- a/website/docs/configurations/02-gpu-drivers.md
+++ b/website/docs/configurations/02-gpu-drivers.md
@@ -44,7 +44,7 @@ This section assumes a basic understanding of GPU Operator and its role in Kuber
 Please proceed with GPU operator installation only if you have created the nodepool **with** the `--gpu-driver` field set to `none` as described in [prerequisites documentation](../getting-started/02-prerequisites.md#gpu-operator-managed-gpu-driver).
 :::
 
-GPU Operator is deployed using [Helm](https://helm.sh/), and the [default Helm values](https://github.com/NVIDIA/gpu-operator/blob/v26.3.1/deployments/gpu-operator/values.yaml) are customized to align with the Network Operator and AKS requirements. Key adjustments to the Helm values disable redundant components such as NFD and enable RDMA support.
+GPU Operator is deployed using [Helm](https://helm.sh/), and the [default Helm values](https://github.com/NVIDIA/gpu-operator/blob/v26.3.2/deployments/gpu-operator/values.yaml) are customized to align with the Network Operator and AKS requirements. Key adjustments to the Helm values disable redundant components such as NFD and enable RDMA support.
 
 GPU operator deploys pods that require privileged access to the host system. To ensure proper operation, the `gpu-operator` namespace must be labeled with `pod-security.kubernetes.io/enforce=privileged`.
 
@@ -69,7 +69,7 @@ helm upgrade --install \
   --create-namespace -n gpu-operator \
   gpu-operator nvidia/gpu-operator \
   -f values.yaml \
-  --version v26.3.1
+  --version v26.3.2
 ```
 
 ## Usage of GPUDirect RDMA


### PR DESCRIPTION
## Dependency Updates

- **vllm/vllm-openai** Docker tag → v0.22.0
- **gpu-operator** Helm release → v26.3.2
- **rocm/dev-ubuntu-24.04** Docker tag → v7.2.4

### Commit details

```
chore(deps): update vllm/vllm-openai docker tag to v0.22.0
chore(deps): update helm release gpu-operator to v26.3.2
chore(deps): update rocm/dev-ubuntu-24.04 docker tag to v7.2.4
```