### PR TITLE
fix(setup-infra): add `--timeout 10m` to kube-prometheus helm install

### DIFF
--- a/tests/setup-infra/deploy-aks.sh
+++ b/tests/setup-infra/deploy-aks.sh
@@ -186,6 +186,7 @@ function install_kube_prometheus() {
     helm repo update
     kube_prometheus_install="helm upgrade -i \
         --wait \
+        --timeout 10m \
         -n monitoring \
         --create-namespace \
         kube-prometheus \


### PR DESCRIPTION
Without an explicit `--timeout`, a wedged Helm `--wait` watch (caused by flaky TLS connections to the AKS API server) never exits, so the surrounding `until` retry loop never fires and the install hangs indefinitely. Setting `--timeout 10m` forces Helm to give up and mark the release `failed`, letting the retry loop re-attempt the install.