### PR TITLE
chore(deps): update actions/setup-node action to v7

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,7 +40,7 @@ jobs:
             *.blob.core.windows.net:443
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.x
 


### PR DESCRIPTION
Updates the `actions/setup-node` GitHub Action to v7.0.0 in `.github/workflows/deploy-docs.yml`.

- **actions/setup-node**: v6.4.0 → v7.0.0